### PR TITLE
Update AAP external secrets

### DIFF
--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: innabox/hypershift1/fulfillment-app/cloudkit-aap-cluster-fulfillment-ig
+      key: innabox/hypershift1/fulfillment-aap/cloudkit-aap-cluster-fulfillment-ig
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-ig.yaml
@@ -6,15 +6,10 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: innabox/hypershift1/fulfillment-app/cloudkit-aap-config-as-code-ig
+      key: innabox/hypershift1/fulfillment-aap/cloudkit-aap-config-as-code-ig
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: cluster-secrets
   target:
     name: cloudkit-aap-config-as-code-ig
-    template:
-      engineVersion: v2
-      mergePolicy: Merge
-      data:
-        license.zip: '{{ index . "license.zip" | b64dec }}'  # license.zip is already b64, we don't want external secrets to encode it one more time

--- a/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-manifest-ig.yaml
+++ b/fulfillment-aap/base/externalsecret-cloudkit-aap-config-as-code-manifest-ig.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cloudkit-aap-config-as-code-manifest-ig
+  namespace: fulfillment-aap
+spec:
+  dataFrom:
+  - extract:
+      key: innabox/hypershift1/fulfillment-aap/cloudkit-aap-config-as-code-manifest-ig
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: cluster-secrets
+  target:
+    name: cloudkit-aap-config-as-code-manifest-ig
+    template:
+      engineVersion: v2
+      data:
+        license.zip: '{{ index . "license.zip" | b64dec }}'  # license.zip is already b64, we don't want external secrets to encode it one more time

--- a/fulfillment-aap/base/kustomization.yaml
+++ b/fulfillment-aap/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - rolebinding-aap-fulfillment-template-publisher.yaml
 - externalsecret-cloudkit-aap-cluster-fulfillment-ig.yaml
 - externalsecret-cloudkit-aap-config-as-code-ig.yaml
+- externalsecret-cloudkit-aap-config-as-code-manifest-ig.yaml


### PR DESCRIPTION
- s/app/aap
- split config-as-code secrets into 2 secrets: one for the environment
  variables, and one for the license manifest

x-ref: https://github.com/innabox/cloudkit-aap/pull/74